### PR TITLE
Fixed right click crash in group constraints

### DIFF
--- a/lib/ttime/constraints/group_constraints.rb
+++ b/lib/ttime/constraints/group_constraints.rb
@@ -199,7 +199,9 @@ module TTime
               [ _("Select none"), lambda { select_none } ],
             ].each do |label, block|
               mi = Gtk::MenuItem.new label
-              mi.signal_connect("activate", &block)
+              mi.signal_connect("activate"){
+                block.call()
+              }
               menu.append mi
             end
             menu.show_all


### PR DESCRIPTION
The program crashed whenever a user right-clicked on the group constraints form.
This fix solves the bug and allows the user to select all/none, as intended.

Crash reproduced under Windows 8 and Ubuntu Linux with Ruby 1.9.3.
